### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 C = gcc
 
-CFLAGS = -Wall -Wextra -O2 -s -no-pie -lm -lreadline --std=c99
+CFLAGS = -Wall -Wextra -O2 -no-pie -lm -lreadline --std=c99
 CBITS = $(shell getconf LONG_BIT)
 
 BUILD__ = $(C) clibasic.c $(CFLAGS) -D B$(CBITS) -o clibasic && chmod +x ./clibasic


### PR DESCRIPTION
removed -s option in CFLAGS. gcc ignores this flag because it is obsolete.